### PR TITLE
[Feat #36] 이름 변경 API 구현

### DIFF
--- a/src/main/java/com/example/newsbara/global/common/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/newsbara/global/common/apiPayload/code/status/ErrorStatus.java
@@ -23,7 +23,7 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "USER4003", "비밀번호가 틀립니다."),
     USER_NOT_AUTHENTICATED(HttpStatus.UNAUTHORIZED, "USER4004", "인증된 사용자가 존재하지 않습니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "USER4005","유효하지 않은 토큰입니다."),
-
+    NAME_IS_NULL(HttpStatus.BAD_REQUEST, "USER4006", "이름은 비어있어선 안됩니다."),
     // 파일 관련 에러 추가
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_001", "파일 업로드에 실패하였습니다."),
     FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_002", "파일 삭제에 실패하였습니다."),
@@ -32,6 +32,7 @@ public enum ErrorStatus implements BaseErrorCode {
     TRANSCRIPT_NOT_AVAILABLE(HttpStatus.NOT_FOUND, "TEST4001", "이 동영상은 영어 자막이 없습니다."),
     TRANSCRIPT_EXTRACTION_FAILED(HttpStatus.NOT_FOUND, "TEST4002", "자막 추출에 실패하였습니다."),
     TEST_GENERATION_FAILED(HttpStatus.NOT_FOUND, "TEST4003", "테스트 생성에 실패하였습니다.");
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/example/newsbara/user/controller/MypageController.java
+++ b/src/main/java/com/example/newsbara/user/controller/MypageController.java
@@ -1,12 +1,15 @@
 package com.example.newsbara.user.controller;
 
 import com.example.newsbara.global.common.apiPayload.ApiResponse;
+import com.example.newsbara.user.dto.req.NameReqDto;
 import com.example.newsbara.user.dto.res.MypageResDto;
+import com.example.newsbara.user.dto.res.NameResDto;
 import com.example.newsbara.user.dto.res.UserInfoResDto;
 import com.example.newsbara.user.service.MypageService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -32,5 +35,13 @@ public class MypageController {
     public ApiResponse<MypageResDto> getMypage(Principal principal) {
 
         return ApiResponse.onSuccess(mypageService.getMypage(principal));
+    }
+
+    @PutMapping("/name")
+    @Operation(summary = "이름 수정 API",
+            description = "마이페이지 메인 화면에 있는 회원 정보를 조회하는 API입니다.")
+    public ApiResponse<NameResDto> putName(Principal principal, NameReqDto request) {
+
+        return ApiResponse.onSuccess(mypageService.putName(principal, request));
     }
 }

--- a/src/main/java/com/example/newsbara/user/dto/req/NameReqDto.java
+++ b/src/main/java/com/example/newsbara/user/dto/req/NameReqDto.java
@@ -1,0 +1,15 @@
+package com.example.newsbara.user.dto.req;
+
+import lombok.*;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+@Builder
+public class NameReqDto {
+    @NotNull
+    private String name;
+}

--- a/src/main/java/com/example/newsbara/user/dto/res/NameResDto.java
+++ b/src/main/java/com/example/newsbara/user/dto/res/NameResDto.java
@@ -1,0 +1,23 @@
+package com.example.newsbara.user.dto.res;
+
+import com.example.newsbara.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NameResDto {
+    private Integer id;
+    private String name;
+
+    public static NameResDto fromEntity(User user) {
+        return NameResDto.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .build();
+    }
+}

--- a/src/main/java/com/example/newsbara/user/service/MypageService.java
+++ b/src/main/java/com/example/newsbara/user/service/MypageService.java
@@ -3,7 +3,9 @@ package com.example.newsbara.user.service;
 import com.example.newsbara.global.common.apiPayload.code.status.ErrorStatus;
 import com.example.newsbara.global.common.apiPayload.exception.GeneralException;
 import com.example.newsbara.user.domain.User;
+import com.example.newsbara.user.dto.req.NameReqDto;
 import com.example.newsbara.user.dto.res.MypageResDto;
+import com.example.newsbara.user.dto.res.NameResDto;
 import com.example.newsbara.user.dto.res.UserInfoResDto;
 import com.example.newsbara.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
@@ -20,7 +22,7 @@ public class MypageService {
         this.userRepository = userRepository;
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public MypageResDto getMypage(Principal principal) {
         User user = userRepository.findByEmail(principal.getName())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
@@ -29,4 +31,18 @@ public class MypageService {
 
     }
 
+    @Transactional
+    public NameResDto putName(Principal principal, NameReqDto request) {
+        User user = userRepository.findByEmail(principal.getName())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        if (request.getName() != null && !request.getName().equals("")) {
+            user.setName(request.getName());
+        } else {
+            throw new GeneralException(ErrorStatus.NAME_IS_NULL);
+        }
+
+
+        return NameResDto.fromEntity(userRepository.save(user));
+    }
 }


### PR DESCRIPTION
# 💡 변경 사항
사용자 이름을 변경하는 API

## 이름 변경 API
   - 사용자의 로그인 정보와 변경할 이름을 프론트로 받음
   - `api/mypage/name `엔드포인트로 put 받음
   - MyPageService에서 새로운 이름으로 수정 후 반환
   - 예외처리를 통해 null 값이나 ""과 같이 값이 없는 경우는 변경하지 못하도록 설정



# 🔗 관련 이슈 #36 

# 🖼️ 스크린샷
swagger/postman 상에서 테스트한 결과를 첨부해주세요.
- 수정 전
![스크린샷 2025-06-27 213735](https://github.com/user-attachments/assets/7496d574-d46f-4acb-8612-2e7e3e907ede)
- 수정 후
![스크린샷 2025-06-27 213800](https://github.com/user-attachments/assets/fddbe2fb-9969-484b-9273-6d86cf03b5f4)
![스크린샷 2025-06-27 213811](https://github.com/user-attachments/assets/d82b82e8-c226-452a-bab4-730916eff37e)
- 빈 값을 넣었을 경우
![스크린샷 2025-06-27 215036](https://github.com/user-attachments/assets/8c885930-31cf-4539-b388-8122d4e3347b)

# ✅ 체크리스트
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 필요한 테스트를 추가했습니다.
- [ ] 모든 테스트가 통과합니다.
- [ ] 관련 문서를 업데이트했습니다.