### PR TITLE
[Refactor #49] 닉네임 중복 검사 및 인덱스 변경

### DIFF
--- a/src/main/java/com/example/newsbara/global/common/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/newsbara/global/common/apiPayload/code/status/ErrorStatus.java
@@ -24,6 +24,7 @@ public enum ErrorStatus implements BaseErrorCode {
     USER_NOT_AUTHENTICATED(HttpStatus.UNAUTHORIZED, "USER4004", "인증된 사용자가 존재하지 않습니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "USER4005","유효하지 않은 토큰입니다."),
     NAME_IS_NULL(HttpStatus.BAD_REQUEST, "USER4006", "이름은 비어있어선 안됩니다."),
+    NAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER4007", "이미 존재하는 닉네임입니다."),
 
     // 파일 관련 에러 추가
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE4001", "파일 업로드에 실패하였습니다."),

--- a/src/main/java/com/example/newsbara/history/domain/WatchHistory.java
+++ b/src/main/java/com/example/newsbara/history/domain/WatchHistory.java
@@ -11,8 +11,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "WatchHistory", indexes = {
-        @Index(name = "idx_video_id", columnList = "videoId"),
-        @Index(name = "idx_title", columnList = "title")
+        @Index(name = "idx_user_created_at", columnList = "user_id, created_at DESC")
 })
 @Getter
 @Setter

--- a/src/main/java/com/example/newsbara/user/domain/User.java
+++ b/src/main/java/com/example/newsbara/user/domain/User.java
@@ -32,7 +32,7 @@ public class User extends BaseEntity {
 
     private String phone;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String name;
 
     @Column

--- a/src/main/java/com/example/newsbara/user/repository/UserRepository.java
+++ b/src/main/java/com/example/newsbara/user/repository/UserRepository.java
@@ -4,9 +4,14 @@ import com.example.newsbara.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Integer> {
     Optional<User> findByEmail(String email);
+
+    List<User> name(String name);
+
+    boolean existsByName(String name);
 }

--- a/src/main/java/com/example/newsbara/user/service/MypageService.java
+++ b/src/main/java/com/example/newsbara/user/service/MypageService.java
@@ -47,6 +47,11 @@ public class MypageService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         if (request.getName() != null && !request.getName().equals("")) {
+            if (!request.getName().equals(user.getName()) &&
+                    userRepository.existsByName(request.getName())) {
+                throw new GeneralException(ErrorStatus.NAME_ALREADY_EXISTS);
+            }
+
             user.setName(request.getName());
         } else {
             throw new GeneralException(ErrorStatus.NAME_IS_NULL);

--- a/src/main/java/com/example/newsbara/user/service/UserService.java
+++ b/src/main/java/com/example/newsbara/user/service/UserService.java
@@ -64,6 +64,10 @@ public class UserService {
             }
         }
 
+        if (userRepository.existsByName(request.getName())){
+            throw new GeneralException(ErrorStatus.NAME_ALREADY_EXISTS);
+        }
+
         User user = request.toEntity();
         user.setPassword(passwordEncoder.encode(request.getPassword()));
         User savedUser = userRepository.save(user);


### PR DESCRIPTION
# 💡 변경 사항
이 PR에서 변경한 내용을 간략히 설명해주세요.

## 1. 닉네임 중복 검사
   - 회원가입, 닉네임 변경 시 닉네임이 중복된 닉네임이면 예외처리

## 2. 인덱스 변경
   - 쿼리 성능을 높이기 위해 WatchHistory 에 user_id로 인덱싱 처리


# 🔗 관련 이슈 #49 

# 🖼️ 스크린샷
swagger/postman 상에서 테스트한 결과를 첨부해주세요.

