### PR TITLE
[Feat #53] https로 배포

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -54,11 +54,13 @@ jobs:
       - name: Set deployment environment
         id: set-env
         run: |
-          STATUS=$(curl -o /dev/null -w "%{http_code}" "http://${{ secrets.LIVE_SERVER_IP }}/env" || echo "000")
+          # HTTPS로 변경, fallback을 HTTP로 시도
+          STATUS=$(curl -k -o /dev/null -w "%{http_code}" "https://${{ secrets.DOMAIN_NAME }}/env" 2>/dev/null || curl -o /dev/null -w "%{http_code}" "http://${{ secrets.LIVE_SERVER_IP }}/env" 2>/dev/null || echo "000")
           echo "Status: $STATUS"
           
           if [ "$STATUS" = "200" ]; then
-            CURRENT_UPSTREAM=$(curl -s "http://${{ secrets.LIVE_SERVER_IP }}/env" || echo "green")
+            # HTTPS 우선 시도, 실패하면 HTTP
+            CURRENT_UPSTREAM=$(curl -k -s "https://${{ secrets.DOMAIN_NAME }}/env" 2>/dev/null || curl -s "http://${{ secrets.LIVE_SERVER_IP }}/env" 2>/dev/null || echo "green")
           else
             CURRENT_UPSTREAM="green"
           fi
@@ -101,6 +103,7 @@ jobs:
       - name: Health check new deployment
         uses: jtalk/url-health-check-action@v3
         with:
+          # HTTP로 직접 포트 접근 (HTTPS는 nginx에서만 처리)
           url: http://${{ secrets.LIVE_SERVER_IP }}:${{ needs.build.outputs.stopped_port }}/env
           max-attempts: 5
           retry-delay: 10s
@@ -119,7 +122,8 @@ jobs:
       - name: Verify switch
         uses: jtalk/url-health-check-action@v3
         with:
-          url: http://${{ secrets.LIVE_SERVER_IP }}/env
+          # HTTPS 도메인으로 확인
+          url: https://${{ secrets.DOMAIN_NAME }}/env
           max-attempts: 3
           retry-delay: 5s
 

--- a/src/main/java/com/example/newsbara/global/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/newsbara/global/common/config/WebSecurityConfig.java
@@ -63,7 +63,9 @@ public class WebSecurityConfig {
         CorsConfiguration configuration = new CorsConfiguration();
 
         configuration.setAllowedOriginPatterns(List.of(
-                "http://localhost:3000"  // 추후 프론트 배포 주소 추가
+                "http://localhost:3000",
+                "https://newsbara.duckdns.org"  // 실제 배포 주소 추가
+
         ));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,7 +33,7 @@ spring:
       on-profile: blue
 server:
   port: 8080
-  serverAddress: 3.36.30.174
+  serverAddress: newsbara.duckdns.org
 serverName: blue_server
 
 # Docker 환경에서 쿠키 파일 경로 설정 (절대 경로)
@@ -50,7 +50,7 @@ spring:
       on-profile: green
 server:
   port: 8081
-  serverAddress: 3.36.30.174
+  serverAddress: newsbara.duckdns.org
 serverName: green_server
 
 # Docker 환경에서 쿠키 파일 경로 설정 (절대 경로)


### PR DESCRIPTION
# 💡 변경 사항
이 PR에서 변경한 내용을 간략히 설명해주세요.

## HTTPS 배포
  - nginx에서 Let's Encrypt 이용하여 SSL 인증서 발급
  - 보안 증가

# 🔗 관련 이슈 #53 
