### PR TITLE
[Fix #59] differenceDto 형태 변경

### DIFF
--- a/src/main/java/com/example/newsbara/ai/dto/res/DifferenceDto.java
+++ b/src/main/java/com/example/newsbara/ai/dto/res/DifferenceDto.java
@@ -1,13 +1,52 @@
 package com.example.newsbara.ai.dto.res;
 
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.io.IOException;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonDeserialize(using = DifferenceDto.DifferenceDtoDeserializer.class)
 public class DifferenceDto {
     private String expected;
     private String pronounced;
+
+    public static class DifferenceDtoDeserializer extends JsonDeserializer<DifferenceDto> {
+        @Override
+        public DifferenceDto deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            if (p.getCurrentToken() == JsonToken.START_ARRAY) {
+                // 배열 형태의 데이터 처리: ["expected", "pronounced"]
+                String[] values = p.readValueAs(String[].class);
+                if (values.length >= 2) {
+                    return new DifferenceDto(values[0], values[1]);
+                } else if (values.length == 1) {
+                    return new DifferenceDto(values[0], "");
+                } else {
+                    return new DifferenceDto("", "");
+                }
+            } else if (p.getCurrentToken() == JsonToken.START_OBJECT) {
+                // 객체 형태의 데이터 처리: {"expected": "...", "pronounced": "..."}
+                DifferenceDto dto = new DifferenceDto();
+                while (p.nextToken() != JsonToken.END_OBJECT) {
+                    String fieldName = p.getCurrentName();
+                    p.nextToken();
+                    if ("expected".equals(fieldName)) {
+                        dto.setExpected(p.getText());
+                    } else if ("pronounced".equals(fieldName)) {
+                        dto.setPronounced(p.getText());
+                    }
+                }
+                return dto;
+            }
+            throw new IOException("Cannot deserialize DifferenceDto from " + p.getCurrentToken());
+        }
+    }
 }


### PR DESCRIPTION
# 💡 변경 사항
이 PR에서 변경한 내용을 간략히 설명해주세요.

## DifferenceDto 형태 변경
- ML API가 differences 필드에서 배열의 배열 형태로 데이터를 반환하고 있는데, 현재 DifferenceDto는 객체 형태를 기대하고 있어서 오류 발생
- 실제 응답
```json
{
  "differences": [
    ["expected_word1", "pronounced_word1"],
    ["expected_word2", "pronounced_word2"]
  ]
}
```
- 이전 코드
```json
{
  "differences": [
    {"expected": "expected_word1", "pronounced": "pronounced_word1"},
    {"expected": "expected_word2", "pronounced": "pronounced_word2"}
  ]
}
```
- 커스텀 Deserializer 사용하여 수정

   📎 샘플 데이터 (선택)
<img width="851" height="622" alt="image" src="https://github.com/user-attachments/assets/bdce7ac6-f7eb-4575-b8f5-b38ad6459fbf" />


